### PR TITLE
New color naming

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -497,6 +497,15 @@
           "type": "color"
         }
       }
+    },
+    "spacing": {
+      "margin": {
+        "base": {
+          "value": "16px",
+          "description": "16px base spacing token",
+          "type": "spacing"
+        }
+      }
     }
   }
 }

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -379,17 +379,17 @@
       },
       "neutral": {
         "100": {
-          "value": "#f2f2ec",
+          "value": "{base.gray.100}",
           "type": "color",
           "description": "Light Dice Gray"
         },
         "200": {
-          "value": "#a5a199",
+          "value": "{base.gray.300}",
           "type": "color",
           "description": "Medium Dice Gray"
         },
         "300": {
-          "value": "#585450",
+          "value": "{base.gray.500}",
           "type": "color",
           "description": "Dark Dice Gray"
         }
@@ -397,22 +397,22 @@
     },
     "utility": {
       "caution": {
-        "value": "#eebe57",
+        "value": "{base.yellow.500}",
         "type": "color",
         "description": "Caution"
       },
       "success": {
-        "value": "#2a6437",
+        "value": "{base.green.500}",
         "type": "color",
         "description": "Success"
       },
       "danger": {
-        "value": "#952827",
+        "value": "{base.red.600}",
         "type": "color",
         "description": "Error"
       },
       "interaction": {
-        "value": "#195581",
+        "value": "{base.blue.500}",
         "type": "color",
         "description": "Links, buttons, etc"
       }
@@ -420,24 +420,24 @@
     "typography": {
       "primary": {
         "heading": {
-          "value": "#2b2927",
+          "value": "{base.gray.700}",
           "type": "color",
           "description": "Heading default color"
         },
         "paragraph": {
-          "value": "#2b2927",
+          "value": "{base.gray.700}",
           "type": "color",
           "description": "default paragraph color"
         },
         "display": {
-          "value": "#2b2927",
+          "value": "{base.gray.700}",
           "type": "color",
           "description": "Default color for Display headings. "
         }
       },
       "component": {
         "eyebrow": {
-          "value": "#741429",
+          "value": "{brand.secondary}",
           "type": "color",
           "description": "Component eyebrow type color."
         }
@@ -446,12 +446,12 @@
     "button": {
       "primary": {
         "background": {
-          "value": "#195581",
+          "value": "{utility.interaction}",
           "type": "color",
           "description": "Primary Button Background Color"
         },
         "text": {
-          "value": "#ffffff",
+          "value": "{base.white}",
           "type": "color",
           "description": "Primary Button Text Color"
         }
@@ -460,12 +460,12 @@
     "border": {
       "primary": {
         "divider": {
-          "value": "#d4d2ce",
+          "value": "{base.gray.200}",
           "type": "color",
           "description": "Default divider color"
         },
         "card": {
-          "value": "#d4d2ce",
+          "value": "{base.gray.200}",
           "type": "color",
           "description": "Primary card border color. "
         }
@@ -474,7 +474,7 @@
     "header": {
       "primary": {
         "background": {
-          "value": "#2b2927",
+          "value": "{base.gray.700}",
           "type": "color",
           "description": "Background color for the global header of Dice.com"
         }
@@ -483,27 +483,17 @@
     "footer": {
       "primary": {
         "background": {
-          "value": "#2b2927",
+          "value": "{base.gray.700}",
           "type": "color",
           "description": "The main background to the footer which contains foot navigation links."
         }
       },
       "secondary": {
         "background": {
-          "value": "#1b1918",
+          "value": "{base.gray.800}",
           "type": "color",
           "description": "Background for the footer section containing copyright information on dice.com"
         }
-      }
-    },
-    "Documentation": {
-      "👽 OFF": {
-        "value": "#7b61ff00",
-        "type": "color"
-      },
-      "👽  ON": {
-        "value": "#7b61ff",
-        "type": "color"
       }
     }
   }

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -355,26 +355,26 @@
         "description": "Dice Red. Used in logo, marketing banners, decorations. "
       },
       "secondary": {
-        "value": "#741429",
+        "value": "{base.magenta.500}",
         "type": "color",
         "description": "Dice Magenta. "
       },
       "tertiary": {
-        "value": "#28494f",
+        "value": "{base.teal.500}",
         "type": "color",
         "description": "Dice Teal"
       },
       "quaternary": {
-        "value": "#bdd4d7",
+        "value": "{base.cyan.400}",
         "type": "color",
         "description": "Dice Cyan"
       },
       "black": {
-        "value": "#000000",
+        "value": "{base.black}",
         "type": "color"
       },
       "white": {
-        "value": "#ffffff",
+        "value": "{base.white}",
         "type": "color"
       },
       "neutral": {

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -350,7 +350,7 @@
     },
     "brand": {
       "primary": {
-        "value": "#be3432",
+        "value": "{base.red.500}",
         "type": "color",
         "description": "Dice Red. Used in logo, marketing banners, decorations. "
       },

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -12,473 +12,446 @@
         "description": "base white"
       },
       "red": {
-        "red-100": {
-          "value": "#F9EBEB",
-          "description": "Base red-100",
-          "type": "color"
+        "100": {
+          "value": "#f9ebeb",
+          "type": "color",
+          "description": "Base red-100"
         },
-        "red-200": {
-          "value": "#E4ACAB",
-          "description": "base red-200",
-          "type": "color"
+        "200": {
+          "value": "#e4acab",
+          "type": "color",
+          "description": "base red-200"
         },
-        "red-300": {
-          "value": "#D98988",
-          "description": "base red-300",
-          "type": "color"
+        "300": {
+          "value": "#d98988",
+          "type": "color",
+          "description": "base red-300"
         },
-        "red-400": {
-          "value": "#C95755",
-          "description": "base red-400",
-          "type": "color"
+        "400": {
+          "value": "#c95755",
+          "type": "color",
+          "description": "base red-400"
         },
-        "red-500": {
-          "value": "#BE3432",
-          "description": "base red-500",
-          "type": "color"
+        "500": {
+          "value": "#be3432",
+          "type": "color",
+          "description": "base red-500"
         },
-        "red-600": {
+        "600": {
           "value": "#952827",
-          "description": "base red-600",
-          "type": "color"
+          "type": "color",
+          "description": "base red-600"
         },
-        "red-700": {
-          "value": "#6D1E1D",
-          "description": "base red-700",
-          "type": "color"
+        "700": {
+          "value": "#6d1e1d",
+          "type": "color",
+          "description": "base red-700"
         },
-        "red-800": {
+        "800": {
           "value": "#451312",
-          "description": "base red-800",
-          "type": "color"
+          "type": "color",
+          "description": "base red-800"
         }
       },
       "magenta": {
-        "magenta-100": {
-          "value": "#F1E8EA",
-          "description": "base magenta-100",
-          "type": "color"
+        "100": {
+          "value": "#f1e8ea",
+          "type": "color",
+          "description": "base magenta-100"
         },
-        "magenta-200": {
-          "value": "#C69FA7",
-          "description": "base magenta-200",
-          "type": "color"
+        "200": {
+          "value": "#c69fa7",
+          "type": "color",
+          "description": "base magenta-200"
         },
-        "magenta-300": {
-          "value": "#AE7783",
-          "description": "base magenta-300",
-          "type": "color"
+        "300": {
+          "value": "#ae7783",
+          "type": "color",
+          "description": "base magenta-300"
         },
-        "magenta-400": {
-          "value": "#8C3C4D",
-          "description": "base magenta-400",
-          "type": "color"
+        "400": {
+          "value": "#8c3c4d",
+          "type": "color",
+          "description": "base magenta-400"
         },
-        "magenta-500": {
+        "500": {
           "value": "#741429",
-          "description": "base magenta-500",
-          "type": "color"
+          "type": "color",
+          "description": "base magenta-500"
         },
-        "magenta-600": {
-          "value": "#510E1D",
-          "description": "base magenta-600",
-          "type": "color"
+        "600": {
+          "value": "#510e1d",
+          "type": "color",
+          "description": "base magenta-600"
         },
-        "magenta-700": {
-          "value": "#390A14",
-          "description": "base magenta-700",
-          "type": "color"
+        "700": {
+          "value": "#390a14",
+          "type": "color",
+          "description": "base magenta-700"
         },
-        "magenta-800": {
-          "value": "#27070E",
-          "description": "base magenta-800",
-          "type": "color"
+        "800": {
+          "value": "#27070e",
+          "type": "color",
+          "description": "base magenta-800"
         }
       },
       "teal": {
-        "teal-100": {
-          "value": "#EAEDED",
-          "description": "base teal-100",
-          "type": "color"
+        "100": {
+          "value": "#eaeded",
+          "type": "color",
+          "description": "base teal-100"
         },
-        "teal-200": {
-          "value": "#A7B4B7",
-          "description": "base teal-200",
-          "type": "color"
+        "200": {
+          "value": "#a7b4b7",
+          "type": "color",
+          "description": "base teal-200"
         },
-        "teal-300": {
+        "300": {
           "value": "#829599",
-          "description": "base teal-300",
-          "type": "color"
+          "type": "color",
+          "description": "base teal-300"
         },
-        "teal-400": {
-          "value": "#4D686D",
-          "description": "base teal-400",
-          "type": "color"
+        "400": {
+          "value": "#4d686d",
+          "type": "color",
+          "description": "base teal-400"
         },
-        "teal-500": {
-          "value": "#28494F",
-          "description": "base teal-500",
-          "type": "color"
+        "500": {
+          "value": "#28494f",
+          "type": "color",
+          "description": "base teal-500"
         },
-        "teal-600": {
-          "value": "#1C3337",
-          "description": "base teal-600",
-          "type": "color"
+        "600": {
+          "value": "#1c3337",
+          "type": "color",
+          "description": "base teal-600"
         },
-        "teal-700": {
-          "value": "#111F22",
-          "description": "base teal-700",
-          "type": "color"
+        "700": {
+          "value": "#111f22",
+          "type": "color",
+          "description": "base teal-700"
         },
-        "teal-800": {
-          "value": "#0C1618",
-          "description": "base teal-800",
-          "type": "color"
+        "800": {
+          "value": "#0c1618",
+          "type": "color",
+          "description": "base teal-800"
         }
       },
       "cyan": {
-        "cyan-100": {
-          "value": "#F5F9F9",
-          "description": "base cyan-100",
-          "type": "color"
+        "100": {
+          "value": "#f5f9f9",
+          "type": "color",
+          "description": "base cyan-100"
         },
-        "cyan-200": {
-          "value": "#E9F1F2",
-          "description": "base cyan-200",
-          "type": "color"
+        "200": {
+          "value": "#e9f1f2",
+          "type": "color",
+          "description": "base cyan-200"
         },
-        "cyan-300": {
-          "value": "#D6E4E6",
-          "description": "base cyan-300",
-          "type": "color"
+        "300": {
+          "value": "#d6e4e6",
+          "type": "color",
+          "description": "base cyan-300"
         },
-        "cyan-400": {
-          "value": "#BDD4D7",
-          "description": "base cyan-400",
-          "type": "color"
+        "400": {
+          "value": "#bdd4d7",
+          "type": "color",
+          "description": "base cyan-400"
         },
-        "cyan-500": {
-          "value": "#8FB5BC",
-          "description": "base cyan-500",
-          "type": "color"
+        "500": {
+          "value": "#8fb5bc",
+          "type": "color",
+          "description": "base cyan-500"
         },
-        "cyan-600": {
-          "value": "#669AA3",
-          "description": "base cyan-600",
-          "type": "color"
+        "600": {
+          "value": "#669aa3",
+          "type": "color",
+          "description": "base cyan-600"
         },
-        "cyan-700": {
-          "value": "#4D7880",
-          "description": "base cyan-700",
-          "type": "color"
+        "700": {
+          "value": "#4d7880",
+          "type": "color",
+          "description": "base cyan-700"
         },
-        "cyan-800": {
-          "value": "#395A60",
-          "description": "base cyan-800",
-          "type": "color"
+        "800": {
+          "value": "#395a60",
+          "type": "color",
+          "description": "base cyan-800"
         }
       },
       "gray": {
-        "gray-100": {
-          "value": "#F2F2EC",
-          "description": "base gray-100",
-          "type": "color"
+        "100": {
+          "value": "#f2f2ec",
+          "type": "color",
+          "description": "base gray-100"
         },
-        "gray-200": {
-          "value": "#D4D2CE",
-          "description": "base gray-200",
-          "type": "color"
+        "200": {
+          "value": "#d4d2ce",
+          "type": "color",
+          "description": "base gray-200"
         },
-        "gray-300": {
-          "value": "#A5A199",
-          "description": "base gray-300",
-          "type": "color"
+        "300": {
+          "value": "#a5a199",
+          "type": "color",
+          "description": "base gray-300"
         },
-        "gray-400": {
-          "value": "#837E77",
-          "description": "base gray-400",
-          "type": "color"
+        "400": {
+          "value": "#837e77",
+          "type": "color",
+          "description": "base gray-400"
         },
-        "gray-500": {
+        "500": {
           "value": "#585450",
-          "description": "base gray-500",
-          "type": "color"
+          "type": "color",
+          "description": "base gray-500"
         },
-        "gray-600": {
-          "value": "#3E3B38",
-          "description": "base gray-600",
-          "type": "color"
+        "600": {
+          "value": "#3e3b38",
+          "type": "color",
+          "description": "base gray-600"
         },
-        "gray-700": {
-          "value": "#2B2927",
-          "description": "base gray-700",
-          "type": "color"
+        "700": {
+          "value": "#2b2927",
+          "type": "color",
+          "description": "base gray-700"
         },
-        "gray-800": {
-          "value": "#1B1918",
-          "description": "base gray-800",
-          "type": "color"
+        "800": {
+          "value": "#1b1918",
+          "type": "color",
+          "description": "base gray-800"
         }
       },
       "yellow": {
-        "yellow-100": {
-          "value": "#FDF9EE",
-          "description": "base yellow-100",
-          "type": "color"
+        "100": {
+          "value": "#fdf9ee",
+          "type": "color",
+          "description": "base yellow-100"
         },
-        "yellow-200": {
-          "value": "#F8E4BA",
-          "description": "base yellow-200",
-          "type": "color"
+        "200": {
+          "value": "#f8e4ba",
+          "type": "color",
+          "description": "base yellow-200"
         },
-        "yellow-300": {
-          "value": "#F5D99E",
-          "description": "base yellow-300",
-          "type": "color"
+        "300": {
+          "value": "#f5d99e",
+          "type": "color",
+          "description": "base yellow-300"
         },
-        "yellow-400": {
-          "value": "#F1C974",
-          "description": "base yellow-400",
-          "type": "color"
+        "400": {
+          "value": "#f1c974",
+          "type": "color",
+          "description": "base yellow-400"
         },
-        "yellow-500": {
-          "value": "#EEBE57",
-          "description": "base yellow-500",
-          "type": "color"
+        "500": {
+          "value": "#eebe57",
+          "type": "color",
+          "description": "base yellow-500"
         },
-        "yellow-600": {
-          "value": "#E8A517",
-          "description": "base yellow-600",
-          "type": "color"
+        "600": {
+          "value": "#e8a517",
+          "type": "color",
+          "description": "base yellow-600"
         },
-        "yellow-700": {
-          "value": "#BA8512",
-          "description": "base yellow-700",
-          "type": "color"
+        "700": {
+          "value": "#ba8512",
+          "type": "color",
+          "description": "base yellow-700"
         },
-        "yellow-800": {
-          "value": "#8E6610",
-          "description": "base yellow-800",
-          "type": "color"
+        "800": {
+          "value": "#8e6610",
+          "type": "color",
+          "description": "base yellow-800"
         }
       },
       "green": {
-        "green-100": {
-          "value": "#EAF0EB",
-          "description": "base green-100",
-          "type": "color"
+        "100": {
+          "value": "#eaf0eb",
+          "type": "color",
+          "description": "base green-100"
         },
-        "green-200": {
-          "value": "#A8BFAD",
-          "description": "base green-200",
-          "type": "color"
+        "200": {
+          "value": "#a8bfad",
+          "type": "color",
+          "description": "base green-200"
         },
-        "green-300": {
-          "value": "#83A58B",
-          "description": "base green-300",
-          "type": "color"
+        "300": {
+          "value": "#83a58b",
+          "type": "color",
+          "description": "base green-300"
         },
-        "green-400": {
-          "value": "#4E7E59",
-          "description": "base green-400",
-          "type": "color"
+        "400": {
+          "value": "#4e7e59",
+          "type": "color",
+          "description": "base green-400"
         },
-        "green-500": {
-          "value": "#2A6437",
-          "description": "base green-500",
-          "type": "color"
+        "500": {
+          "value": "#2a6437",
+          "type": "color",
+          "description": "base green-500"
         },
-        "green-600": {
-          "value": "#1D4626",
-          "description": "base green-600",
-          "type": "color"
+        "600": {
+          "value": "#1d4626",
+          "type": "color",
+          "description": "base green-600"
         },
-        "green-700": {
-          "value": "#122B18",
-          "description": "base green-700",
-          "type": "color"
+        "700": {
+          "value": "#122b18",
+          "type": "color",
+          "description": "base green-700"
         },
-        "green-800": {
-          "value": "#0B190E",
-          "description": "base green-800",
-          "type": "color"
+        "800": {
+          "value": "#0b190e",
+          "type": "color",
+          "description": "base green-800"
         }
       },
       "blue": {
-        "blue-100": {
-          "value": "#E8EEF2",
-          "description": "base blue-100",
-          "type": "color"
+        "100": {
+          "value": "#e8eef2",
+          "type": "color",
+          "description": "base blue-100"
         },
-        "blue-200": {
-          "value": "#A1B9CB",
-          "description": "base blue-200",
-          "type": "color"
+        "200": {
+          "value": "#a1b9cb",
+          "type": "color",
+          "description": "base blue-200"
         },
-        "blue-300": {
-          "value": "#7A9CB6",
-          "description": "base blue-300",
-          "type": "color"
+        "300": {
+          "value": "#7a9cb6",
+          "type": "color",
+          "description": "base blue-300"
         },
-        "blue-400": {
+        "400": {
           "value": "#407296",
-          "description": "base blue-400",
-          "type": "color"
+          "type": "color",
+          "description": "base blue-400"
         },
-        "blue-500": {
+        "500": {
           "value": "#195581",
-          "description": "base blue-500",
-          "type": "color"
+          "type": "color",
+          "description": "base blue-500"
         },
-        "blue-600": {
-          "value": "#123B5A",
-          "description": "base blue-600",
-          "type": "color"
+        "600": {
+          "value": "#123b5a",
+          "type": "color",
+          "description": "base blue-600"
         },
-        "blue-700": {
-          "value": "#0C2A40",
-          "description": "base blue-700",
-          "type": "color"
+        "700": {
+          "value": "#0c2a40",
+          "type": "color",
+          "description": "base blue-700"
         },
-        "blue-800": {
+        "800": {
           "value": "#071927",
-          "description": "base blue-800",
-          "type": "color"
+          "type": "color",
+          "description": "base blue-800"
         }
       }
     },
     "brand": {
       "primary": {
-        "primary": {
-          "value": "{base.red.red-500}",
-          "description": "Dice Red. Used in logo, marketing banners, decorations. ",
-          "type": "color"
-        }
+        "value": "#be3432",
+        "type": "color",
+        "description": "Dice Red. Used in logo, marketing banners, decorations. "
       },
       "secondary": {
-        "secondary-1": {
-          "value": "{base.teal.teal-500}",
-          "description": "Dice Teal",
-          "type": "color"
-        },
-        "secondary-2": {
-          "value": "{base.cyan.cyan-400}",
-          "description": "Dice Cyan",
-          "type": "color"
-        },
-        "secondary-3": {
-          "value": "{base.magenta.magenta-500}",
-          "description": "Dice Magenta. ",
-          "type": "color"
-        }
+        "value": "#741429",
+        "type": "color",
+        "description": "Dice Magenta. "
+      },
+      "tertiary": {
+        "value": "#28494f",
+        "type": "color",
+        "description": "Dice Teal"
+      },
+      "quaternary": {
+        "value": "#bdd4d7",
+        "type": "color",
+        "description": "Dice Cyan"
+      },
+      "black": {
+        "value": "#000000",
+        "type": "color"
+      },
+      "white": {
+        "value": "#ffffff",
+        "type": "color"
       },
       "neutral": {
-        "neutral-1": {
-          "value": "{base.gray.gray-100}",
-          "description": "Light Dice Gray",
-          "type": "color"
+        "100": {
+          "value": "#f2f2ec",
+          "type": "color",
+          "description": "Light Dice Gray"
         },
-        "neutral-2": {
-          "value": "{base.gray.gray-300}",
-          "description": "Medium Dice Gray",
-          "type": "color"
+        "200": {
+          "value": "#a5a199",
+          "type": "color",
+          "description": "Medium Dice Gray"
         },
-        "neutral-3": {
-          "value": "{base.gray.gray-500}",
-          "description": "Dark Dice Gray",
-          "type": "color"
-        },
-        "black": {
-          "value": "{base.black}",
-          "type": "color"
-        },
-        "white": {
-          "value": "{base.white}",
-          "type": "color"
+        "300": {
+          "value": "#585450",
+          "type": "color",
+          "description": "Dark Dice Gray"
         }
       }
     },
     "utility": {
       "caution": {
-        "value": "{base.yellow.yellow-500}",
-        "description": "Caution",
-        "type": "color"
+        "value": "#eebe57",
+        "type": "color",
+        "description": "Caution"
       },
       "success": {
-        "value": "{base.green.green-500}",
-        "description": "Success",
-        "type": "color"
+        "value": "#2a6437",
+        "type": "color",
+        "description": "Success"
       },
       "danger": {
-        "value": "{base.red.red-600}",
-        "description": "Error",
-        "type": "color"
+        "value": "#952827",
+        "type": "color",
+        "description": "Error"
       },
       "interaction": {
-        "value": "{base.blue.blue-500}",
-        "description": "Links, buttons, etc",
-        "type": "color"
+        "value": "#195581",
+        "type": "color",
+        "description": "Links, buttons, etc"
       }
     },
     "typography": {
       "primary": {
         "heading": {
-          "value": "{base.gray.gray-700}",
+          "value": "#2b2927",
           "type": "color",
           "description": "Heading default color"
         },
         "paragraph": {
-          "value": "{base.gray.gray-700}",
+          "value": "#2b2927",
           "type": "color",
           "description": "default paragraph color"
         },
         "display": {
-          "value": "{base.gray.gray-700}",
-          "description": "Default color for Display headings. ",
-          "type": "color"
-        },
-        "eyebrow": {
-          "value": "{base.magenta.magenta-500}",
-          "description": "Component eyebrow type color.",
-          "type": "color"
-        }
-      }
-    },
-    "header": {
-      "primary": {
-        "background": {
-          "value": "{base.gray.gray-700}",
-          "description": "Background color for the global header of Dice.com",
-          "type": "color"
-        }
-      }
-    },
-    "footer": {
-      "primary": {
-        "background": {
-          "value": "{base.gray.gray-700}",
-          "description": "The main background to the footer which contains foot navigation links.",
-          "type": "color"
+          "value": "#2b2927",
+          "type": "color",
+          "description": "Default color for Display headings. "
         }
       },
-      "secondary": {
-        "background": {
-          "value": "{base.gray.gray-800}",
-          "description": "Background for the footer section containing copyright information on dice.com",
-          "type": "color"
+      "component": {
+        "eyebrow": {
+          "value": "#741429",
+          "type": "color",
+          "description": "Component eyebrow type color."
         }
       }
     },
     "button": {
       "primary": {
         "background": {
-          "value": "{utility.interaction}",
+          "value": "#195581",
           "type": "color",
           "description": "Primary Button Background Color"
         },
         "text": {
-          "value": "{base.white}",
+          "value": "#ffffff",
           "type": "color",
           "description": "Primary Button Text Color"
         }
@@ -487,24 +460,50 @@
     "border": {
       "primary": {
         "divider": {
-          "value": "{base.gray.gray-200}",
-          "description": "Default divider color",
-          "type": "color"
+          "value": "#d4d2ce",
+          "type": "color",
+          "description": "Default divider color"
         },
         "card": {
-          "value": "{base.gray.gray-200}",
-          "description": "Primary card border color. ",
-          "type": "color"
+          "value": "#d4d2ce",
+          "type": "color",
+          "description": "Primary card border color. "
         }
       }
     },
-    "spacing": {
-      "margin": {
-        "base": {
-          "value": "16px",
-          "description": "16px base spacing token",
-          "type": "spacing"
+    "header": {
+      "primary": {
+        "background": {
+          "value": "#2b2927",
+          "type": "color",
+          "description": "Background color for the global header of Dice.com"
         }
+      }
+    },
+    "footer": {
+      "primary": {
+        "background": {
+          "value": "#2b2927",
+          "type": "color",
+          "description": "The main background to the footer which contains foot navigation links."
+        }
+      },
+      "secondary": {
+        "background": {
+          "value": "#1b1918",
+          "type": "color",
+          "description": "Background for the footer section containing copyright information on dice.com"
+        }
+      }
+    },
+    "Documentation": {
+      "👽 OFF": {
+        "value": "#7b61ff00",
+        "type": "color"
+      },
+      "👽  ON": {
+        "value": "#7b61ff",
+        "type": "color"
       }
     }
   }


### PR DESCRIPTION
Updated naming conventions to remove redundancy from dev tokens. 

Instead of tokens being {base.gray.gray-700} they are now {base.gray.700}

Additionally, brand colors have been renamed to communicate their hierarchy within the UI: 

- brand.primary
- brand.secondary
- brand.tertiary
- brand.quaternary