### PR TITLE
Spacing tokens 25 - 1250 added.

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1,5 +1,70 @@
 {
   "global": {
+    "25": {
+      "value": "{100} * 0.25",
+      "type": "spacing"
+    },
+    "50": {
+      "value": "{100} * 0.5",
+      "type": "spacing"
+    },
+    "100": {
+      "value": "1rem",
+      "description": "Base spacing token (16px / 1rem)",
+      "type": "spacing"
+    },
+    "150": {
+      "value": "{100} * 1.5",
+      "type": "spacing"
+    },
+    "200": {
+      "value": "{100} * 2",
+      "type": "spacing"
+    },
+    "250": {
+      "value": "{100} * 2.5",
+      "type": "spacing"
+    },
+    "300": {
+      "value": "{100} * 3",
+      "type": "spacing"
+    },
+    "350": {
+      "value": "{100} * 3.5",
+      "type": "spacing"
+    },
+    "400": {
+      "value": "{100} * 4",
+      "type": "spacing"
+    },
+    "450": {
+      "value": "{100} * 4.5",
+      "type": "spacing"
+    },
+    "500": {
+      "value": "{100} * 5",
+      "type": "spacing"
+    },
+    "550": {
+      "value": "{100} * 5.5",
+      "type": "spacing"
+    },
+    "600": {
+      "value": "{100} * 6",
+      "type": "spacing"
+    },
+    "650": {
+      "value": "{100} * 6.5",
+      "type": "spacing"
+    },
+    "1000": {
+      "value": "{100} * 10",
+      "type": "spacing"
+    },
+    "1250": {
+      "value": "{100} * 12.5",
+      "type": "spacing"
+    },
     "base": {
       "black": {
         "value": "#000000",


### PR DESCRIPTION
Spacing tokens that match Figma Doc tokens here: 

Tokens are named after a percentage derived from the REM value of the spacing. Rem value assumes a 16px base. 

Example: 

spacing.100 = 16px = 1rem
spacing.150 = spacing.100 * 1.5 = 1.5rem