### PR TITLE
Spacing tokens rem

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1,11 +1,11 @@
 {
   "global": {
     "25": {
-      "value": "{100} * 0.25",
+      "value": "0.25rem",
       "type": "spacing"
     },
     "50": {
-      "value": "{100} * 0.5",
+      "value": "0.5rem",
       "type": "spacing"
     },
     "100": {
@@ -14,55 +14,55 @@
       "type": "spacing"
     },
     "150": {
-      "value": "{100} * 1.5",
+      "value": "1.5rem",
       "type": "spacing"
     },
     "200": {
-      "value": "{100} * 2",
+      "value": "2rem",
       "type": "spacing"
     },
     "250": {
-      "value": "{100} * 2.5",
+      "value": "2.5rem",
       "type": "spacing"
     },
     "300": {
-      "value": "{100} * 3",
+      "value": "3rem",
       "type": "spacing"
     },
     "350": {
-      "value": "{100} * 3.5",
+      "value": "3.5rem",
       "type": "spacing"
     },
     "400": {
-      "value": "{100} * 4",
+      "value": "4rem",
       "type": "spacing"
     },
     "450": {
-      "value": "{100} * 4.5",
+      "value": "4.5rem",
       "type": "spacing"
     },
     "500": {
-      "value": "{100} * 5",
+      "value": "5rem",
       "type": "spacing"
     },
     "550": {
-      "value": "{100} * 5.5",
+      "value": "5.5rem",
       "type": "spacing"
     },
     "600": {
-      "value": "{100} * 6",
+      "value": "6rem",
       "type": "spacing"
     },
     "650": {
-      "value": "{100} * 6.5",
+      "value": "6.5rem",
       "type": "spacing"
     },
     "1000": {
-      "value": "{100} * 10",
+      "value": "10rem",
       "type": "spacing"
     },
     "1250": {
-      "value": "{100} * 12.5",
+      "value": "12.5rem",
       "type": "spacing"
     },
     "base": {


### PR DESCRIPTION
Removed math in tokens, replaced with REM values because by nature, they are already relative. 🤦‍♂️