### PR TITLE
Exd 632 text input tokens

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2073,7 +2073,7 @@
           },
           "size": {
             "87": {
-              "value": "21px",
+              "value": "21 px",
               "type": "sizing"
             },
             "100": {

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2399,6 +2399,62 @@
       }
     }
   },
+  "form": {
+    "form": {
+      "input": {
+        "head": {
+          "label": {
+            "value": {
+              "fontFamily": "{typography.fontFamilies.primary}",
+              "fontWeight": "{typography.fontWeights.medium}",
+              "lineHeight": "{typography.lineHeights.primary}",
+              "fontSize": "{typography.fontSizes.100}",
+              "letterSpacing": "",
+              "textDecoration": ""
+            },
+            "type": "typography",
+            "color": {
+              "default": {
+                "value": "{color.typography.primary.paragraph}",
+                "type": "color"
+              },
+              "required": {
+                "value": "{color.utility.danger}",
+                "type": "color"
+              },
+              "optional": {
+                "value": "{color.base.gray.500}",
+                "type": "color"
+              }
+            }
+          },
+          "required": {
+            "value": {
+              "fontFamily": "{typography.fontFamilies.primary}",
+              "fontWeight": "{typography.fontWeights.medium}",
+              "lineHeight": "{typography.lineHeights.primary}",
+              "fontSize": "{typography.fontSizes.100}",
+              "letterSpacing": "",
+              "textDecoration": ""
+            },
+            "type": "typography"
+          },
+          "optional": {
+            "value": {
+              "fontFamily": "{typography.fontFamilies.primary}",
+              "fontWeight": "{typography.fontWeights.medium}",
+              "fontSize": "{typography.fontSizes.75}"
+            },
+            "type": "typography"
+          },
+          "gap": {
+            "value": "{spacing.25}",
+            "type": "spacing"
+          }
+        }
+      }
+    }
+  },
   "$themes": [],
   "$metadata": {
     "tokenSetOrder": [
@@ -2411,7 +2467,8 @@
       "atom",
       "animation",
       "nav",
-      "layout"
+      "layout",
+      "form"
     ]
   }
 }

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -490,12 +490,12 @@
       },
       "lineHeights": {
         "primary": {
-          "value": "1.5",
+          "value": "150%",
           "type": "lineHeights",
           "description": "Primary Line Height of 150%"
         },
         "secondary": {
-          "value": "1.2",
+          "value": "120%",
           "type": "lineHeights"
         }
       },

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2073,7 +2073,7 @@
           },
           "size": {
             "87": {
-              "value": "21 px",
+              "value": "21px",
               "type": "sizing"
             },
             "100": {

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2480,7 +2480,7 @@
           },
           "border": {
             "radius": {
-              "value": "{spacing.50}",
+              "value": "{border.radius.50}",
               "type": "borderRadius"
             },
             "width": {
@@ -2532,6 +2532,18 @@
               },
               "success": {
                 "value": "{color.utility.success}",
+                "type": "color"
+              }
+            }
+          },
+          "text": {
+            "color": {
+              "hint": {
+                "value": "{color.base.gray.500}",
+                "type": "color"
+              },
+              "user": {
+                "value": "{color.typography.primary.paragraph}",
                 "type": "color"
               }
             }

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2403,53 +2403,138 @@
     "form": {
       "input": {
         "head": {
-          "label": {
-            "value": {
-              "fontFamily": "{typography.fontFamilies.primary}",
-              "fontWeight": "{typography.fontWeights.medium}",
-              "lineHeight": "{typography.lineHeights.primary}",
-              "fontSize": "{typography.fontSizes.100}",
-              "letterSpacing": "",
-              "textDecoration": ""
-            },
-            "type": "typography",
-            "color": {
-              "default": {
-                "value": "{color.typography.primary.paragraph}",
-                "type": "color"
+          "typography": {
+            "label": {
+              "value": {
+                "fontFamily": "{typography.fontFamilies.primary}",
+                "fontWeight": "{typography.fontWeights.medium}",
+                "lineHeight": "{typography.lineHeights.primary}",
+                "fontSize": "{typography.fontSizes.100}",
+                "letterSpacing": "",
+                "textDecoration": ""
               },
-              "required": {
-                "value": "{color.utility.danger}",
-                "type": "color"
-              },
-              "optional": {
-                "value": "{color.base.gray.500}",
-                "type": "color"
+              "type": "typography",
+              "color": {
+                "default": {
+                  "value": "{color.typography.primary.paragraph}",
+                  "type": "color"
+                },
+                "required": {
+                  "value": "{color.utility.danger}",
+                  "type": "color"
+                },
+                "optional": {
+                  "value": "{color.base.gray.500}",
+                  "type": "color"
+                }
               }
+            },
+            "required": {
+              "value": {
+                "fontFamily": "{typography.fontFamilies.primary}",
+                "fontWeight": "{typography.fontWeights.medium}",
+                "lineHeight": "{typography.lineHeights.primary}",
+                "fontSize": "{typography.fontSizes.100}",
+                "letterSpacing": "",
+                "textDecoration": ""
+              },
+              "type": "typography"
+            },
+            "optional": {
+              "value": {
+                "fontFamily": "{typography.fontFamilies.primary}",
+                "fontWeight": "{typography.fontWeights.medium}",
+                "fontSize": "{typography.fontSizes.75}"
+              },
+              "type": "typography"
             }
-          },
-          "required": {
-            "value": {
-              "fontFamily": "{typography.fontFamilies.primary}",
-              "fontWeight": "{typography.fontWeights.medium}",
-              "lineHeight": "{typography.lineHeights.primary}",
-              "fontSize": "{typography.fontSizes.100}",
-              "letterSpacing": "",
-              "textDecoration": ""
-            },
-            "type": "typography"
-          },
-          "optional": {
-            "value": {
-              "fontFamily": "{typography.fontFamilies.primary}",
-              "fontWeight": "{typography.fontWeights.medium}",
-              "fontSize": "{typography.fontSizes.75}"
-            },
-            "type": "typography"
           },
           "gap": {
             "value": "{spacing.25}",
             "type": "spacing"
+          }
+        },
+        "field": {
+          "typography": {
+            "text": {
+              "value": {
+                "fontFamily": "{typography.fontFamilies.primary}",
+                "fontWeight": "{typography.fontWeights.regular}",
+                "lineHeight": "{typography.lineHeights.primary}",
+                "fontSize": "{typography.fontSizes.100}"
+              },
+              "type": "typography",
+              "hint": {
+                "value": "{color.base.gray.500}",
+                "type": "color"
+              },
+              "user": {
+                "value": "{color.typography.primary.paragraph}",
+                "type": "color"
+              }
+            }
+          },
+          "padding": {
+            "value": "{spacing.50} {spacing.75}",
+            "type": "spacing"
+          },
+          "border": {
+            "radius": {
+              "value": "{spacing.50}",
+              "type": "borderRadius"
+            },
+            "width": {
+              "default": {
+                "value": "1px",
+                "type": "borderWidth"
+              },
+              "hover": {
+                "value": "2px",
+                "type": "borderWidth"
+              },
+              "active": {
+                "value": "2px",
+                "type": "borderWidth"
+              },
+              "focus": {
+                "value": "2px",
+                "type": "borderWidth"
+              },
+              "danger": {
+                "value": "2px",
+                "type": "borderWidth"
+              },
+              "success": {
+                "value": "2px",
+                "type": "borderWidth"
+              }
+            },
+            "color": {
+              "default": {
+                "value": "{color.base.gray.400}",
+                "type": "color"
+              },
+              "hover": {
+                "value": "{color.base.gray.400}",
+                "type": "color"
+              },
+              "active": {
+                "value": "{color.utility.interaction}",
+                "type": "color"
+              },
+              "focus": {
+                "value": "{border.focus.color}",
+                "type": "color"
+              },
+              "danger": {
+                "value": "{color.utility.danger}",
+                "type": "color"
+              },
+              "success": {
+                "value": "{color.utility.success}",
+                "type": "color"
+              }
+            }
           }
         }
       }

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2086,6 +2086,26 @@
           "value": "{spacing.25}",
           "type": "spacing"
         }
+      },
+      "info": {
+        "icon": {
+          "size": {
+            "default": {
+              "value": "{spacing.150}",
+              "type": "sizing"
+            }
+          },
+          "color": {
+            "default": {
+              "value": "{color.utility.interaction}",
+              "type": "color"
+            },
+            "hover": {
+              "value": "{color.utility.interaction-hover}",
+              "type": "color"
+            }
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
Added:
- dhi-seds-forms-input-head tokens
- dhi-seds-atom-info tokens
- dhi-seds-forms-text-input tokens. 

Changed:
- primary and secondary line-heights changed from 1.5 and 1.2 to 150% and 120% respectively. This is to fix a bug in Figma, and should be fine since we found better ways to transform the tokens in Style Dictionary. 